### PR TITLE
Add Laravel skeleton for Mikrotik radius management

### DIFF
--- a/laravel/.env.example
+++ b/laravel/.env.example
@@ -1,0 +1,8 @@
+APP_NAME=Laravel
+APP_ENV=local
+APP_KEY=
+APP_DEBUG=true
+APP_URL=http://localhost
+
+RADIUS_HOST=127.0.0.1
+RADIUS_SECRET=secret

--- a/laravel/README.md
+++ b/laravel/README.md
@@ -1,0 +1,16 @@
+# Laravel Mikrotik Radius Management
+
+This is a minimal Laravel skeleton intended to manage Mikrotik Radius servers.
+
+## Setup
+
+1. Install dependencies (requires internet access):
+   ```bash
+   composer install
+   ```
+2. Copy `.env.example` to `.env` and configure Mikrotik Radius connection details.
+3. Start the application:
+   ```bash
+   php artisan serve
+   ```
+4. Access `http://localhost:8000/radius` to view a JSON list of Radius users (currently placeholder).

--- a/laravel/app/Http/Controllers/Controller.php
+++ b/laravel/app/Http/Controllers/Controller.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Routing\Controller as BaseController;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+
+class Controller extends BaseController
+{
+    use DispatchesJobs, ValidatesRequests;
+}

--- a/laravel/app/Http/Controllers/RadiusController.php
+++ b/laravel/app/Http/Controllers/RadiusController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\Mikrotik\RadiusService;
+
+class RadiusController extends Controller
+{
+    public function index(RadiusService $service)
+    {
+        return response()->json([
+            'users' => $service->listUsers(),
+        ]);
+    }
+}

--- a/laravel/app/Http/Kernel.php
+++ b/laravel/app/Http/Kernel.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http;
+
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
+
+class Kernel extends HttpKernel
+{
+    /**
+     * The application's global HTTP middleware stack.
+     *
+     * @var array<int, class-string|string>
+     */
+    protected $middleware = [];
+}

--- a/laravel/app/Services/Mikrotik/RadiusService.php
+++ b/laravel/app/Services/Mikrotik/RadiusService.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Services\Mikrotik;
+
+class RadiusService
+{
+    public function listUsers(): array
+    {
+        // TODO: Implement retrieval of radius users via Mikrotik API
+        return [];
+    }
+}

--- a/laravel/artisan
+++ b/laravel/artisan
@@ -1,0 +1,10 @@
+<?php
+
+require __DIR__.'/vendor/autoload.php';
+
+$app = require_once __DIR__.'/bootstrap/app.php';
+
+$app->make(Illuminate\Contracts\Console\Kernel::class)->handle(
+    new Symfony\Component\Console\Input\ArgvInput,
+    new Symfony\Component\Console\Output\ConsoleOutput
+);

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -1,0 +1,14 @@
+<?php
+
+use Illuminate\Foundation\Application;
+
+$app = new Application(
+    $_ENV['APP_BASE_PATH'] ?? dirname(__DIR__)
+);
+
+$app->singleton(
+    Illuminate\Contracts\Http\Kernel::class,
+    App\Http\Kernel::class
+);
+
+return $app;

--- a/laravel/composer.json
+++ b/laravel/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "mikhmon/laravel-mikrotik-radius",
+    "description": "Laravel-based Mikrotik radius management",
+    "type": "project",
+    "require": {
+        "php": "^8.2",
+        "laravel/framework": "^11.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    },
+    "scripts": {
+        "test": "phpunit"
+    }
+}

--- a/laravel/public/index.php
+++ b/laravel/public/index.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Http\Request;
+
+require __DIR__.'/../vendor/autoload.php';
+
+$app = require_once __DIR__.'/../bootstrap/app.php';
+
+$kernel = $app->make(Illuminate\Contracts\Http\Kernel::class);
+
+$response = $kernel->handle(
+    $request = Request::capture()
+);
+
+$response->send();
+
+$kernel->terminate($request, $response);

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,0 +1,6 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\RadiusController;
+
+Route::get('/radius', [RadiusController::class, 'index']);


### PR DESCRIPTION
## Summary
- introduce `laravel/` directory with minimal Laravel-based skeleton
- add `RadiusService` and `RadiusController` with `/radius` route placeholder
- document setup steps and environment example for Mikrotik Radius

## Testing
- `php -l laravel/routes/web.php`
- `php -l laravel/app/Services/Mikrotik/RadiusService.php`
- `php -l laravel/app/Http/Controllers/Controller.php`
- `php -l laravel/app/Http/Controllers/RadiusController.php`
- `php -l laravel/app/Http/Kernel.php`
- `php -l laravel/bootstrap/app.php`
- `php -l laravel/public/index.php`
- `php -l laravel/artisan`
- `composer install` *(fails: curl error 56 - CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f1eea8064832b83edd0db48979c16